### PR TITLE
Don't adjust the conversation view's insets if the view was displayed…

### DIFF
--- a/Code/Controllers/ATLBaseConversationViewController.m
+++ b/Code/Controllers/ATLBaseConversationViewController.m
@@ -211,6 +211,9 @@ static CGFloat const ATLMaxScrollDistanceFromBottom = 150;
 
 - (void)keyboardWillShow:(NSNotification *)notification
 {
+    if ([[self navigationController] modalPresentationStyle] == UIModalPresentationPopover) {
+        return;
+    }
     [self configureWithKeyboardNotification:notification];
 }
 


### PR DESCRIPTION
I'm not sure if this works in all cases (do I need to check parent view controllers recursively?).  But, works for us and seems reasonably clean.
